### PR TITLE
Use the most recent version of jplock/zookeeper

### DIFF
--- a/dev-env/fig.yml.template
+++ b/dev-env/fig.yml.template
@@ -7,7 +7,7 @@ mysql:
 
 
 zookeeper:
-  image: jplock/zookeeper
+  image: jplock/zookeeper:3.4.6
   ports:
     - "2181"
 


### PR DESCRIPTION
The maintainer of the zookeeper image does not keep the 'latest' tag up
to date, so we have to manually request it.

See https://registry.hub.docker.com/u/jplock/zookeeper/

The particular reason for using the latest version is to work around
this bug in Docker 1.3: https://github.com/docker/docker/issues/9327
(The bug is triggered with 'jplock/zookeeper:latest' but not with
'jplock/zookeeper:3.4.6'.)
